### PR TITLE
Changes to CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if ( ${_codegen} STREQUAL "GPU" )
 	set ( CUDA_COMPILE_FLAGS -rdc=false )
 	set ( GPU_COMPILE_DEFNS )			## -Xptxas -v
 	set ( LIBS_FOR_CUDA cufft )
-	set ( ADDL_COMPILE_FLAGS -DWIN64 )
+	set ( ADDL_COMPILE_FLAGS -DWIN64 -D_USE_MATH_DEFINES )
     else ()
 	set ( CUDA_COMPILE_FLAGS -m64 -rdc=true )
 	set ( GPU_COMPILE_DEFNS -dc )		## -Xptxas -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ else ()
     message ( STATUS "_codegen = ${_codegen}" )
 endif ()
 
+set ( ADDL_COMPILE_FLAGS -D_USE_MATH_DEFINES )
 if ( ${_codegen} STREQUAL "GPU" )
     if (WIN32)
 	set ( CUDA_COMPILE_FLAGS -rdc=false )

--- a/examples/hockney/CMakeLists.txt
+++ b/examples/hockney/CMakeLists.txt
@@ -32,6 +32,8 @@ list ( APPEND _all_build_srcs ${BUILD_PROGRAM}.${_suffix} )
 add_executable   ( ${BUILD_PROGRAM} ${_all_build_srcs} )
 add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
+target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
+
 if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
     target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
 endif ()

--- a/examples/rconv/CMakeLists.txt
+++ b/examples/rconv/CMakeLists.txt
@@ -32,6 +32,8 @@ list ( APPEND _all_build_srcs ${BUILD_PROGRAM}.${_suffix} )
 add_executable   ( ${BUILD_PROGRAM} ${_all_build_srcs} )
 add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
+target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
+
 if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
     target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
 endif ()

--- a/examples/rconv/testrconv.cpp
+++ b/examples/rconv/testrconv.cpp
@@ -1,4 +1,3 @@
-#define _USE_MATH_DEFINES
 #include <cmath> // Without this, abs is the wrong function!
 #include <random>
 // #include "rconv2.fftx.codegen.hpp"

--- a/examples/rconv/testrconv.cu
+++ b/examples/rconv/testrconv.cu
@@ -1,4 +1,3 @@
-#define _USE_MATH_DEFINES
 #include <cmath> // Without this, abs is the wrong function!
 #include <random>
 // #include "rconv2.fftx.codegen.hpp"

--- a/examples/test_plan_dft/CMakeLists.txt
+++ b/examples/test_plan_dft/CMakeLists.txt
@@ -32,6 +32,8 @@ list ( APPEND _all_build_srcs ${BUILD_PROGRAM}.${_suffix} )
 add_executable   ( ${BUILD_PROGRAM} ${_all_build_srcs} )
 add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
+target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
+
 if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
     target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
 endif ()

--- a/examples/verify/CMakeLists.txt
+++ b/examples/verify/CMakeLists.txt
@@ -32,6 +32,8 @@ list ( APPEND _all_build_srcs ${BUILD_PROGRAM}.${_suffix} )
 add_executable   ( ${BUILD_PROGRAM} ${_all_build_srcs} )
 add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
+target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
+
 if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
     target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
 endif ()

--- a/examples/verify/testverify.cpp
+++ b/examples/verify/testverify.cpp
@@ -1,4 +1,3 @@
-#define _USE_MATH_DEFINES
 #include <cmath> // Without this, abs returns zero!
 #include <random>
 /*

--- a/examples/verify/testverify.cu
+++ b/examples/verify/testverify.cu
@@ -1,4 +1,3 @@
-#define _USE_MATH_DEFINES
 #include <cmath> // Without this, abs returns zero!
 #include <random>
 /*

--- a/examples/warpx/CMakeLists.txt
+++ b/examples/warpx/CMakeLists.txt
@@ -32,6 +32,8 @@ list ( APPEND _all_build_srcs ${BUILD_PROGRAM}.${_suffix} )
 add_executable   ( ${BUILD_PROGRAM} ${_all_build_srcs} )
 add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
+target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
+
 if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
     target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
 endif ()


### PR DESCRIPTION
Windows requires the use of _USE_MATH_DEFINES before <cmath> or <match.h> is included in order to have the M_PI defined.  However, nvcc apparently includes <cmath> prior to parsing the code, thereby negating the presence of the #define in the source code.  Define it on the command line (make it a default for windows)