### PR TITLE
Develop

### DIFF
--- a/CMakeIncludes/FFTXCmakeFunctions.cmake
+++ b/CMakeIncludes/FFTXCmakeFunctions.cmake
@@ -23,7 +23,9 @@ function ( run_driver_program prefix stem )
     set     ( _driver ${PROJECT_NAME}.${prefix}.${stem}.driver )
     set     ( ${prefix}_driver ${prefix}.${stem}.driver PARENT_SCOPE )
     add_executable ( ${_driver} ${prefix}.${stem}.cpp )
+    target_compile_options ( ${_driver} PRIVATE ${ADDL_COMPILE_FLAGS} )
     set_property ( TARGET ${_driver} PROPERTY CXX_STANDARD 14 )
+    message ( STATUS "Added ${ADDL_COMPILE_FLAGS} to target: ${_driver}" )
 
     if ( ${ARGC} GREATER 2 )
 	##  received optional include directories -- add to target

--- a/CMakeIncludes/FFTXSetup.cmake
+++ b/CMakeIncludes/FFTXSetup.cmake
@@ -1,0 +1,92 @@
+##
+## Copyright (c) 2018-2021, Carnegie Mellon University
+## All rights reserved.
+##
+## See LICENSE file for full information
+##
+
+##  Define variables and items required for building FFTX.  This module is intended to be
+##  included by the top level CMake to build the entire project, but also may be included
+##  at a lower level to support generating multiple sizes/sample builds within a single
+##  example in the population of FFTX/examples
+
+## specify this only here, lower levels use CMAKE_MINIMUM_REQUIRED_VERSION that this sets
+cmake_minimum_required (VERSION 3.14)
+
+##  Get SPIRAL home...
+
+if ( DEFINED ENV{SPIRAL_HOME} )
+    message ( STATUS "SPIRAL_HOME = $ENV{SPIRAL_HOME}" )
+    set ( SPIRAL_SOURCE_DIR $ENV{SPIRAL_HOME} )
+else ()
+    if ( "x${SPIRAL_HOME}" STREQUAL "x" )
+        message ( FATAL_ERROR "SPIRAL_HOME environment variable undefined and not specified on command line" )
+    endif ()
+    set ( SPIRAL_SOURCE_DIR ${SPIRAL_HOME} )
+endif ()
+
+##  Find python3 -- used to marshall/run examples
+
+find_package (Python3 COMPONENTS Interpreter)
+if (${Python3_FOUND})
+    ##  It exists, executable is ${Python3_EXECUTABLE}
+    message ( STATUS "Found Python3: Version = ${Python3_VERSION}, Executable = ${Python3_EXECUTABLE}")
+else ()
+    message ( SEND_ERROR "Python3 NOT FOUND: Python is required to build/run examples")
+endif ()
+
+##  Define paths and include other CMake functions needed for building
+
+set ( SPIRAL_INCLUDE_PATH ${SPIRAL_SOURCE_DIR}/config/CMakeIncludes )
+include ("${SPIRAL_INCLUDE_PATH}/RunSpiral.cmake")
+
+set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+set ( BACKEND_SOURCE_DIR ${FFTX_PROJECT_SOURCE_DIR}/examples/backend )
+
+##  message ( STATUS "FFTX_PROJECT_SOURCE_DIR set to: ${FFTX_PROJECT_SOURCE_DIR}" )
+##  message ( STATUS "BACKEND_SOURCE_DIR set to: ${BACKEND_SOURCE_DIR}" )
+
+include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXCmakeFunctions.cmake" )
+##  message ( STATUS "FFTX_CMAKE_INCLUDE_DIR set to: ${FFTX_CMAKE_INCLUDE_DIR}" )
+
+##  Set flags and options for use when building code
+
+set ( ADDL_COMPILE_FLAGS -D_USE_MATH_DEFINES )
+if ( ${_codegen} STREQUAL "GPU" )
+    if (WIN32)
+	set ( CUDA_COMPILE_FLAGS -rdc=false )
+	set ( GPU_COMPILE_DEFNS )			## -Xptxas -v
+	set ( LIBS_FOR_CUDA cufft )
+	set ( ADDL_COMPILE_FLAGS -DWIN64 -D_USE_MATH_DEFINES )
+    else ()
+	set ( CUDA_COMPILE_FLAGS -m64 -rdc=true )
+	set ( GPU_COMPILE_DEFNS -dc )		## -Xptxas -v
+	set ( LIBS_FOR_CUDA cufft culibos )
+	set ( ADDL_COMPILE_FLAGS )
+    endif ()
+
+    set ( CMAKE_CUDA_ARCHITECTURES 52 )
+    set ( GPU_EXTRAS _CUDAGEN )
+endif ()
+
+if ( "x${DIM_X}" STREQUAL "x" )
+    ##  DIM_X is not defined (on command line).  Assume building with default sizes only
+    message ( STATUS "Building for default size example only" )
+else ()
+    ## DIM_X is defined (presumably DIM_Y & DIM_Z also since they come form a script)
+    list ( APPEND ADDL_COMPILE_FLAGS -Dnx=${DIM_X} -Dny=${DIM_Y} -Dnz=${DIM_Z} )
+    message ( STATUS "Building for size [ ${DIM_X}, ${DIM_Y}, ${DIM_Z} ]" )
+endif ()
+
+##  Set include paths and require C++ 14 standard
+
+set ( FFTX_INCLUDE ${FFTX_PROJECT_SOURCE_DIR}/include )
+set ( CMAKE_C_STANDARD 14)
+set ( CMAKE_CXX_STANDARD 14)
+
+include_directories ( ${FFTX_INCLUDE} ${SPIRAL_SOURCE_DIR}/profiler/targets )
+
+if ( (NOT DEFINED CMAKE_BUILD_TYPE) OR (NOT CMAKE_BUILD_TYPE) )
+    set ( CMAKE_BUILD_TYPE Release )
+endif ()
+

--- a/CMakeIncludes/FFTXSetup.cmake
+++ b/CMakeIncludes/FFTXSetup.cmake
@@ -81,7 +81,7 @@ endif ()
 ##  Set include paths and require C++ 14 standard
 
 set ( FFTX_INCLUDE ${FFTX_PROJECT_SOURCE_DIR}/include )
-set ( CMAKE_C_STANDARD 14)
+set ( CMAKE_C_STANDARD 11)
 set ( CMAKE_CXX_STANDARD 14)
 
 include_directories ( ${FFTX_INCLUDE} ${SPIRAL_SOURCE_DIR}/profiler/targets )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,36 +26,6 @@ if ( DISALLOW_COMPILE_INPLACE )
                  make | make install")
 endif ()
 
-##  Get SPIRAL home...
-
-if ( DEFINED ENV{SPIRAL_HOME} )
-    message ( STATUS "SPIRAL_HOME = $ENV{SPIRAL_HOME}" )
-    set ( SPIRAL_SOURCE_DIR $ENV{SPIRAL_HOME} )
-else ()
-    if ( "x${SPIRAL_HOME}" STREQUAL "x" )
-        message ( FATAL_ERROR "SPIRAL_HOME environment variable undefined and not specified on command line" )
-    endif ()
-    set ( SPIRAL_SOURCE_DIR ${SPIRAL_HOME} )
-endif ()
-
-##  Find python3 -- used to marshall/run examples
-
-find_package (Python3 COMPONENTS Interpreter)
-if (${Python3_FOUND})
-    ##  It exists, executable is ${Python3_EXECUTABLE}
-    message ( STATUS "Found Python3: Version = ${Python3_VERSION}, Executable = ${Python3_EXECUTABLE}")
-else ()
-    message ( SEND_ERROR "Python3 NOT FOUND: Python is required to build/run examples")
-endif ()
-
-set ( SPIRAL_INCLUDE_PATH ${SPIRAL_SOURCE_DIR}/config/CMakeIncludes )
-include ("${SPIRAL_INCLUDE_PATH}/RunSpiral.cmake")
-
-set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
-set ( BACKEND_SOURCE_DIR ${FFTX_PROJECT_SOURCE_DIR}/examples/backend )
-
-include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXCmakeFunctions.cmake" )
-
 ##  Check the code generation option ...
 
 if ( "X${_codegen}" STREQUAL "X" )
@@ -65,40 +35,18 @@ else ()
     message ( STATUS "_codegen = ${_codegen}" )
 endif ()
 
-set ( ADDL_COMPILE_FLAGS -D_USE_MATH_DEFINES )
-if ( ${_codegen} STREQUAL "GPU" )
-    if (WIN32)
-	set ( CUDA_COMPILE_FLAGS -rdc=false )
-	set ( GPU_COMPILE_DEFNS )			## -Xptxas -v
-	set ( LIBS_FOR_CUDA cufft )
-	set ( ADDL_COMPILE_FLAGS -DWIN64 -D_USE_MATH_DEFINES )
-    else ()
-	set ( CUDA_COMPILE_FLAGS -m64 -rdc=true )
-	set ( GPU_COMPILE_DEFNS -dc )		## -Xptxas -v
-	set ( LIBS_FOR_CUDA cufft_static culibos )
-	set ( ADDL_COMPILE_FLAGS )
-    endif ()
+##  Define CMake include directory and include the setup information
+set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 
-    set ( CMAKE_CUDA_ARCHITECTURES 52 )
-    set ( GPU_EXTRAS _CUDAGEN )
-endif ()
-
-set ( FFTX_INCLUDE ${FFTX_PROJECT_SOURCE_DIR}/include )
-set ( CMAKE_C_STANDARD 14)
-set ( CMAKE_CXX_STANDARD 14)
-
-include_directories ( ${FFTX_INCLUDE} ${SPIRAL_SOURCE_DIR}/profiler/targets )
-
-if ( (NOT DEFINED CMAKE_BUILD_TYPE) OR (NOT CMAKE_BUILD_TYPE) )
-    set ( CMAKE_BUILD_TYPE Release )
-endif ()
+##  Walk the following subdirectories...
 
 add_subdirectory ( src )
 add_subdirectory ( examples )
 
 ##  We will only build the documentation if the following conditions are satisfied:
 ##    FFTX_MAKE_DOCS is defined when cmake is invoked (e.g., cmake -DFFTX_MAKE_DOCS=True ..)
-##    Sphinx is installed (also breathe & sp[hinx_rtd_theme)
+##    Sphinx is installed (also breathe & sphinx_rtd_theme)
 ##    Doxygen is installed
 
 if ( "X${FFTX_MAKE_DOCS}X" STREQUAL "XX" OR NOT FFTX_MAKE_DOCS )

--- a/examples/rconv/CMakeLists.txt
+++ b/examples/rconv/CMakeLists.txt
@@ -5,6 +5,32 @@
 ## See LICENSE file for full information
 ##
 
+if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
+    ##  CMake minimum version is not defined -- which means this cmake was invoked
+    ##  standalone (i.e., via the buildexamples script).
+    ##  For now assume we want GPU...
+    set ( _codegen GPU )
+
+    ##  FFTX_PROJECT_SOURCE_DIR must be set, get it from FFTX_PROJ_DIR which must be
+    ##  (either environment or command line)
+    if ( DEFINED ENV{FFTX_PROJ_DIR} )
+	message ( STATUS "FFTX_PROJ_DIR = $ENV{FFTX_PROJ_DIR}" )
+	set ( FFTX_PROJECT_SOURCE_DIR $ENV{FFTX_PROJ_DIR} )
+    else ()
+	if ( "x${FFTX_PROJ_DIR}" STREQUAL "x" )
+	    message ( FATAL_ERROR "FFTX_PROJ_DIR variable must be defined" )
+	endif ()
+	set ( FFTX_PROJECT_SOURCE_DIR ${FFTX_PROJ_DIR} )
+    endif ()
+    
+    ##  Setup / determine the necessary paths and variable to continue)
+    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
+
+    ##  Languages aren't defined yet so add c & c++
+    set ( _lang_base C CXX )
+endif ()
+
 cmake_minimum_required ( VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION} )
 
 ##  _codegen specifies CPU or GPU (serial or CUDA) code generation.  Will be set
@@ -14,8 +40,10 @@ if ( ${_codegen} STREQUAL "GPU" )
     set ( _lang_add LANGUAGES CUDA )
 endif ()
 
+##  ===== For most examples you should not need to modify anything ABOVE this line =====
+
 ##  Set the project name.  Preferred name is just the *name* of the example folder 
-project ( rconv ${_lang_add} )
+project ( rconv ${_lang_add} ${_lang_base} )
 
 ##  File nameing convention is: <prefix>.<stem>.xxxxx; set _stem and _prefix(es)
 ##  Test program name is:  test<project name>.{cpp|cu}
@@ -24,7 +52,7 @@ set ( _stem fftx )
 set ( _prefixes rconv3 )
 set ( BUILD_PROGRAM test${PROJECT_NAME} )
 
-##  ===== For most examples you should not need to modify anything below this line =====
+##  ===== For most examples you should not need to modify anything BELOW this line =====
 
 manage_deps_codegen ( ${_codegen} ${_stem} "${_prefixes}" )
 list ( APPEND _all_build_srcs ${BUILD_PROGRAM}.${_suffix} )

--- a/examples/rconv/buildexamples.py
+++ b/examples/rconv/buildexamples.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 
 ##  Run cmake and build to build the code.  CMake isn't being called from the top
 ##  level FFTX folder, so it won't know the FFTX Project source directory -- we'll
@@ -92,6 +93,7 @@ with open ( 'process-sizes.txt', 'r' ) as fil:
         shutil.copy2 ( _target, _newloc )
 
         os.chdir ( '..' )
+        time.sleep(1)
 
 
 sys.exit (0)

--- a/examples/rconv/buildexamples.py
+++ b/examples/rconv/buildexamples.py
@@ -1,0 +1,99 @@
+#! python
+
+##  Copyright (c) 2018-2021, Carnegie Mellon University
+##  See LICENSE for details
+
+##  This script reads a file, process-sizes.txt, that contains several cube size
+##  specifications for the 3D DFT.  The script will run the FFTX generation process for
+##  each size, using CMake; the final executable will be renamed to append the size spec.
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+##  Run cmake and build to build the code.  CMake isn't being called from the top
+##  level FFTX folder, so it won't know the FFTX Project source directory -- we'll
+##  assume its 2 levels up from this [current] directory, define it as a variable
+##  to pass to CMake
+
+_cdir = os.getcwd()
+_base = os.path.basename ( _cdir )
+_fftx = os.path.join ( _cdir, '../..' )
+_fftx = os.path.abspath (_fftx )
+##  print ( 'CWD: ' + _cdir + '; Basename: ' + _base + '; FFTX Project dir: ' + _fftx )
+
+with open ( 'process-sizes.txt', 'r' ) as fil:
+    for line in fil.readlines():
+        ##  print ( 'Line read = ' + line )
+        if re.match ( '[ \t]*#', line ):                ## ignore comment lines
+            continue
+
+        if re.match ( '[ \t]*$', line ):                ## skip lines consisting of whitespace
+            continue
+        
+        line = re.sub ( '.*\[', '', line )               ## drop "szcube := ["
+        line = re.sub ( '\].*', '', line )               ## drop "];"
+        line = re.sub ( ' *', '', line )                 ## compress out white space
+        line = line.rstrip()                             ## remove training newline
+        dims = re.split ( ',', line )
+        _dimx = dims[0]
+        _dimy = dims[1]
+        _dimz = dims[2]
+
+        ##  Use these dimensions in defines passed on the CMake command line -- CMake in
+        ##  turn will generate the needed C language defines to be used when compiling
+        ##  Create the build directory (if it doesn't exist)
+        build_dir = 'build'
+        isdir = os.path.isdir ( build_dir )
+        if not isdir:
+            os.mkdir ( build_dir )
+
+        ##  We'll keep executables we build in an 'executables' folder, create if necessary
+        exec_dir = 'executables'
+        isdir = os.path.isdir ( exec_dir )
+        if not isdir:
+            os.mkdir ( exec_dir )
+        
+        ##  Build the commnd line for CMake...
+        cmdstr = 'rm -rf * && cmake -DFFTX_PROJ_DIR=' + _fftx
+        cmdstr = cmdstr + ' -DDIM_X=' + _dimx + ' -DDIM_Y=' + _dimy + ' -DDIM_Z=' + _dimz
+
+        os.chdir ( build_dir )
+
+        if sys.platform == 'win32':
+            cmdstr = cmdstr + ' .. && cmake --build . --config Release --target install'
+        else:
+            cmdstr = cmdstr + ' .. && make install'
+
+        ##  print ( cmdstr )
+        ##  continue                    ## testing script, stop here
+
+        result = subprocess.run ( cmdstr, shell=True, check=True )
+        res = result.returncode
+
+        if (res != 0):
+            print ( result )
+            sys.exit ( res )
+
+        ##  CMake has built the example [_target] and placed it in the ./bin folder
+        ##  Rename the executable to have a cube size spec on the end and move to
+        ##  ../exeutables folder
+        
+        _suffix = '-' + _dimx + 'x' + _dimy + 'x' + _dimz
+        _target = 'bin/test' + _base
+        _newloc = '../' + exec_dir + '/test' + _base + _suffix
+        if sys.platform == 'win32':
+            _target = _target + '.exe'
+            _newloc = _newloc + '.exe'
+
+        ##  print ( 'Target built: ' + _target + ' Move to: ' + _newloc )
+        shutil.copy2 ( _target, _newloc )
+
+        os.chdir ( '..' )
+
+
+sys.exit (0)
+
+

--- a/examples/rconv/process-sizes.txt
+++ b/examples/rconv/process-sizes.txt
@@ -1,0 +1,18 @@
+##
+##  Sizes of examples to build
+##  Hash (#) as first non-white space indicates a comment
+##  Lines containing white space only are ignored
+##  All other lines must be valid size specs in the form:
+##  szcube := [ nx, ny, nz ]
+##
+
+szcube := [ 24, 32, 40 ];
+szcube := [ 32, 32, 32 ];
+
+szcube := [ 32, 40, 48 ];
+szcube := [ 64, 48, 48 ];
+
+szcube := [ 64, 64, 64 ];
+szcube := [ 128, 128, 128 ];
+szcube := [ 256, 256, 256 ];
+

--- a/examples/rconv/rconv.h
+++ b/examples/rconv/rconv.h
@@ -5,11 +5,25 @@ namespace rconv
   const int offx = 3;
   const int offy = 5;
   const int offz = 11;
-  
-  const int nx = 24;
-  const int ny = 32;
-  const int nz = 40;
 
+  //  The following constants define the cube/problem size.  The values here are defaults
+  //  and will be used if not over-ridden during the build process
+  //  const int nx = 24;
+  //  const int ny = 32;
+  //  const int nz = 40;
+
+  #ifndef nx
+  #define nx 24
+  #endif
+
+  #ifndef ny
+  #define ny 32
+  #endif
+
+  #ifndef nz
+  #define nz 40
+  #endif
+  
   const int fx = nx/2 + 1;
   const int fy = ny;
   const int fz = nz;


### PR DESCRIPTION
Add buildexamples.py script to orchestrate building the example multiple times for different size cubes.
The size specifications are contained (one per line) in the file process-sizes.txt.
The executables built will have a suffix indicating the size appended to the name and all executables built will be added to a folder called 'executables'.