### PR TITLE
Develop

### DIFF
--- a/examples/buildexamples.py
+++ b/examples/buildexamples.py
@@ -25,6 +25,22 @@ _fftx = os.path.join ( _cdir, '../..' )
 _fftx = os.path.abspath (_fftx )
 ##  print ( 'CWD: ' + _cdir + '; Basename: ' + _base + '; FFTX Project dir: ' + _fftx )
 
+##  CMake will normally run with ${_codegen} defined (if undefined it defaults to CPU)
+##  Check for a command line parameter specifying ${_codegen}, defaul to CPU if missing
+
+_mode = "CPU"                     ## define mode as CPU [default]
+if len ( sys.argv ) < 2:
+    print ( 'Usage: ' + sys.argv[0] + ' [ CPU | GPU | HIP ]; defaulting to CPU' )
+else:
+    _mode = sys.argv[1]
+    if _mode != "CPU" and _mode != "GPU":
+        if _mode == "HIP":
+            print ( sys.argv[0] + ': HIP mode requested - support coming soon, defaulting to CPU' )
+            _mode = "CPU"
+        else:
+            print ( sys.argv[0] + ': unknown mode: ' + _mode + ' exiting...' )
+            sys.exit (-1)
+
 with open ( 'process-sizes.txt', 'r' ) as fil:
     for line in fil.readlines():
         ##  print ( 'Line read = ' + line )
@@ -58,7 +74,7 @@ with open ( 'process-sizes.txt', 'r' ) as fil:
             os.mkdir ( exec_dir )
         
         ##  Build the commnd line for CMake...
-        cmdstr = 'rm -rf * && cmake -DFFTX_PROJ_DIR=' + _fftx
+        cmdstr = 'rm -rf * && cmake -DFFTX_PROJ_DIR=' + _fftx + ' -D_codegen=' + _mode
         cmdstr = cmdstr + ' -DDIM_X=' + _dimx + ' -DDIM_Y=' + _dimy + ' -DDIM_Z=' + _dimz
 
         os.chdir ( build_dir )

--- a/examples/buildexamples.py
+++ b/examples/buildexamples.py
@@ -47,7 +47,7 @@ timefd = open ( _timescript, 'w' )
 timefd.write ( '#! /bin/bash \n\n' )
 timefd.write ( '##  Timing script to run the various transform sizes \n\n' )
 timefd.close()
-##  if sys.platform != 'win32':
+
 _filmode = stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
 os.chmod ( _timescript, _filmode )
 

--- a/examples/buildexamples.py
+++ b/examples/buildexamples.py
@@ -7,7 +7,7 @@
 ##  specifications for the 3D DFT.  The script will run the FFTX generation process for
 ##  each size, using CMake; the final executable will be renamed to append the size spec.
 
-import os
+import os, stat
 import re
 import shutil
 import subprocess
@@ -47,9 +47,9 @@ timefd = open ( _timescript, 'w' )
 timefd.write ( '#! /bin/bash \n\n' )
 timefd.write ( '##  Timing script to run the various transform sizes \n\n' )
 timefd.close()
-if sys.platform != 'win32':
-    _filmode = stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
-    os.chmod ( _timescript, _filmode )
+##  if sys.platform != 'win32':
+_filmode = stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+os.chmod ( _timescript, _filmode )
 
 with open ( 'process-sizes.txt', 'r' ) as fil:
     for line in fil.readlines():

--- a/examples/compare_cufft/CMakeLists.txt
+++ b/examples/compare_cufft/CMakeLists.txt
@@ -62,10 +62,6 @@ add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
 target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
 
-if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
-    target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
-endif ()
-
 target_include_directories ( ${BUILD_PROGRAM} PRIVATE ${${PROJECT_NAME}_BINARY_DIR} ${CMAKE_BINARY_DIR} )
 
 target_link_libraries      ( ${BUILD_PROGRAM} ${LIBS_FOR_CUDA} )

--- a/examples/compare_cufft/CMakeLists.txt
+++ b/examples/compare_cufft/CMakeLists.txt
@@ -8,9 +8,6 @@
 if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
     ##  CMake minimum version is not defined -- which means this cmake was invoked
     ##  standalone (i.e., via the buildexamples script).
-    ##  For now assume we want GPU...
-    set ( _codegen GPU )
-
     ##  FFTX_PROJECT_SOURCE_DIR must be set, get it from FFTX_PROJ_DIR which must be
     ##  (either environment or command line)
     if ( DEFINED ENV{FFTX_PROJ_DIR} )
@@ -22,13 +19,16 @@ if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
 	endif ()
 	set ( FFTX_PROJECT_SOURCE_DIR ${FFTX_PROJ_DIR} )
     endif ()
-    
-    ##  Setup / determine the necessary paths and variable to continue)
-    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
-    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 
     ##  Languages aren't defined yet so add c & c++
     set ( _lang_base C CXX )
+
+    ##  _codegen will be passed on the cmake command line: will be one of CPU | GPU | HIP
+    ##  set ( _codegen GPU )
+
+    ##  Setup / determine the necessary paths and variable to continue)
+    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 endif ()
 
 cmake_minimum_required ( VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION} )

--- a/examples/hockney/CMakeLists.txt
+++ b/examples/hockney/CMakeLists.txt
@@ -8,9 +8,6 @@
 if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
     ##  CMake minimum version is not defined -- which means this cmake was invoked
     ##  standalone (i.e., via the buildexamples script).
-    ##  For now assume we want GPU...
-    set ( _codegen GPU )
-
     ##  FFTX_PROJECT_SOURCE_DIR must be set, get it from FFTX_PROJ_DIR which must be
     ##  (either environment or command line)
     if ( DEFINED ENV{FFTX_PROJ_DIR} )
@@ -22,13 +19,16 @@ if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
 	endif ()
 	set ( FFTX_PROJECT_SOURCE_DIR ${FFTX_PROJ_DIR} )
     endif ()
-    
-    ##  Setup / determine the necessary paths and variable to continue)
-    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
-    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 
     ##  Languages aren't defined yet so add c & c++
     set ( _lang_base C CXX )
+
+    ##  _codegen will be passed on the cmake command line: will be one of CPU | GPU | HIP
+    ##  set ( _codegen GPU )
+
+    ##  Setup / determine the necessary paths and variable to continue)
+    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 endif ()
 
 cmake_minimum_required ( VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION} )

--- a/examples/hockney/CMakeLists.txt
+++ b/examples/hockney/CMakeLists.txt
@@ -62,10 +62,6 @@ add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
 target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
 
-if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
-    target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
-endif ()
-
 target_include_directories ( ${BUILD_PROGRAM} PRIVATE ${${PROJECT_NAME}_BINARY_DIR} ${CMAKE_BINARY_DIR} )
 
 set ( INSTALL_DIR_TARGET ${CMAKE_BINARY_DIR}/bin )

--- a/examples/mddft/CMakeLists.txt
+++ b/examples/mddft/CMakeLists.txt
@@ -8,9 +8,6 @@
 if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
     ##  CMake minimum version is not defined -- which means this cmake was invoked
     ##  standalone (i.e., via the buildexamples script).
-    ##  For now assume we want GPU...
-    set ( _codegen GPU )
-
     ##  FFTX_PROJECT_SOURCE_DIR must be set, get it from FFTX_PROJ_DIR which must be
     ##  (either environment or command line)
     if ( DEFINED ENV{FFTX_PROJ_DIR} )
@@ -22,13 +19,16 @@ if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
 	endif ()
 	set ( FFTX_PROJECT_SOURCE_DIR ${FFTX_PROJ_DIR} )
     endif ()
-    
-    ##  Setup / determine the necessary paths and variable to continue)
-    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
-    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 
     ##  Languages aren't defined yet so add c & c++
     set ( _lang_base C CXX )
+
+    ##  _codegen will be passed on the cmake command line: will be one of CPU | GPU | HIP
+    ##  set ( _codegen GPU )
+
+    ##  Setup / determine the necessary paths and variable to continue)
+    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 endif ()
 
 cmake_minimum_required ( VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION} )

--- a/examples/mddft/CMakeLists.txt
+++ b/examples/mddft/CMakeLists.txt
@@ -62,10 +62,6 @@ add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
 target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
 
-if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
-    target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
-endif ()
-
 target_include_directories ( ${BUILD_PROGRAM} PRIVATE ${${PROJECT_NAME}_BINARY_DIR} ${CMAKE_BINARY_DIR} )
 
 set ( INSTALL_DIR_TARGET ${CMAKE_BINARY_DIR}/bin )

--- a/examples/rconv/CMakeLists.txt
+++ b/examples/rconv/CMakeLists.txt
@@ -8,9 +8,6 @@
 if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
     ##  CMake minimum version is not defined -- which means this cmake was invoked
     ##  standalone (i.e., via the buildexamples script).
-    ##  For now assume we want GPU...
-    set ( _codegen GPU )
-
     ##  FFTX_PROJECT_SOURCE_DIR must be set, get it from FFTX_PROJ_DIR which must be
     ##  (either environment or command line)
     if ( DEFINED ENV{FFTX_PROJ_DIR} )
@@ -22,13 +19,16 @@ if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
 	endif ()
 	set ( FFTX_PROJECT_SOURCE_DIR ${FFTX_PROJ_DIR} )
     endif ()
-    
-    ##  Setup / determine the necessary paths and variable to continue)
-    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
-    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 
     ##  Languages aren't defined yet so add c & c++
     set ( _lang_base C CXX )
+
+    ##  _codegen will be passed on the cmake command line: will be one of CPU | GPU | HIP
+    ##  set ( _codegen GPU )
+
+    ##  Setup / determine the necessary paths and variable to continue)
+    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 endif ()
 
 cmake_minimum_required ( VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION} )

--- a/examples/rconv/CMakeLists.txt
+++ b/examples/rconv/CMakeLists.txt
@@ -62,10 +62,6 @@ add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
 target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
 
-if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
-    target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
-endif ()
-
 target_include_directories ( ${BUILD_PROGRAM} PRIVATE ${${PROJECT_NAME}_BINARY_DIR} ${CMAKE_BINARY_DIR} )
 
 set ( INSTALL_DIR_TARGET ${CMAKE_BINARY_DIR}/bin )

--- a/examples/verify/CMakeLists.txt
+++ b/examples/verify/CMakeLists.txt
@@ -8,9 +8,6 @@
 if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
     ##  CMake minimum version is not defined -- which means this cmake was invoked
     ##  standalone (i.e., via the buildexamples script).
-    ##  For now assume we want GPU...
-    set ( _codegen GPU )
-
     ##  FFTX_PROJECT_SOURCE_DIR must be set, get it from FFTX_PROJ_DIR which must be
     ##  (either environment or command line)
     if ( DEFINED ENV{FFTX_PROJ_DIR} )
@@ -22,13 +19,16 @@ if ( "x${CMAKE_MINIMUM_REQUIRED_VERSION}" STREQUAL "x" )
 	endif ()
 	set ( FFTX_PROJECT_SOURCE_DIR ${FFTX_PROJ_DIR} )
     endif ()
-    
-    ##  Setup / determine the necessary paths and variable to continue)
-    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
-    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 
     ##  Languages aren't defined yet so add c & c++
     set ( _lang_base C CXX )
+
+    ##  _codegen will be passed on the cmake command line: will be one of CPU | GPU | HIP
+    ##  set ( _codegen GPU )
+
+    ##  Setup / determine the necessary paths and variable to continue)
+    set ( FFTX_CMAKE_INCLUDE_DIR ${FFTX_PROJECT_SOURCE_DIR}/CMakeIncludes )
+    include ( "${FFTX_CMAKE_INCLUDE_DIR}/FFTXSetup.cmake" )
 endif ()
 
 cmake_minimum_required ( VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION} )

--- a/examples/verify/CMakeLists.txt
+++ b/examples/verify/CMakeLists.txt
@@ -62,10 +62,6 @@ add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
 target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
 
-if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
-    target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
-endif ()
-
 target_include_directories ( ${BUILD_PROGRAM} PRIVATE ${${PROJECT_NAME}_BINARY_DIR} ${CMAKE_BINARY_DIR} )
 
 set ( INSTALL_DIR_TARGET ${CMAKE_BINARY_DIR}/bin )

--- a/examples/warpx/CMakeLists.txt
+++ b/examples/warpx/CMakeLists.txt
@@ -34,10 +34,6 @@ add_dependencies ( ${BUILD_PROGRAM} ${_all_build_deps} )
 
 target_compile_options ( ${BUILD_PROGRAM} PRIVATE ${ADDL_COMPILE_FLAGS} )
 
-if ( ${_codegen} STREQUAL "GPU" AND NOT WIN32 )
-    target_compile_options ( ${BUILD_PROGRAM} PRIVATE -ccbin=${CMAKE_CXX_COMPILER} )
-endif ()
-
 target_include_directories ( ${BUILD_PROGRAM} PRIVATE ${${PROJECT_NAME}_BINARY_DIR} ${CMAKE_BINARY_DIR} . )
 
 set ( INSTALL_DIR_TARGET ${CMAKE_BINARY_DIR}/bin )


### PR DESCRIPTION
Changes to allow buildexamples.py to create for CPU or GPU
Added a placeholder for HIP (but if HIP specified it'll default to CPU for now)
