### PR TITLE
New caching mechanism in C++ rather than SPIRAL

### DIFF
--- a/src/include/interface.hpp
+++ b/src/include/interface.hpp
@@ -185,6 +185,8 @@ inline void printToCache(std::string spiral_out, std::string name, std::vector<i
     }
     #if (defined FFTX_CUDA || FFTX_HIP)
     spiral_out = spiral_out.substr(spiral_out.find("spiral> JIT BEGIN"));
+    #else
+    spiral_out = spiral_out.substr(spiral_out.find("#include"));
     #endif
     cached_file << spiral_out;
     cached_file.close();

--- a/src/include/interface.hpp
+++ b/src/include/interface.hpp
@@ -200,7 +200,13 @@ inline void printJITBackend(std::string name, std::vector<int> sizes) {
     std::string tmp = getFFTX();
     std::cout << "if 1 = 1 then opts:=conf.getOpts(transform);\ntt:= opts.tagIt(transform);\nif(IsBound(fftx_includes)) then opts.includes:=fftx_includes;fi;\nc:=opts.fftxGen(tt);\n fi;\n";
     std::cout << "GASMAN(\"collect\");\n";
-    printToCache(tmp, name, sizes);
+    #if defined FFTX_HIP
+        std::cout << "PrintHIPJIT(c,opts);" << std::endl;
+    #elif defined FFTX_CUDA 
+        std::cout << "PrintJIT2(c,opts);" << std::endl;
+    #else
+        std::cout << "opts.prettyPrint(c);" << std::endl;
+    #endif
 }
 
 class FFTXProblem {

--- a/src/include/interface.hpp
+++ b/src/include/interface.hpp
@@ -180,6 +180,10 @@ inline void printToCache(std::string spiral_out, std::string name, std::vector<i
         file_name.append("_CPU.txt");
     #endif
     cached_file.open(file_name);
+    while(spiral_out.back() != '}') {
+        spiral_out.pop_back();
+    }
+    spiral_out = spiral_out.substr(spiral_out.find("spiral> JIT BEGIN"));
     cached_file << spiral_out;
     cached_file.close();
 

--- a/src/include/interface.hpp
+++ b/src/include/interface.hpp
@@ -185,8 +185,6 @@ inline void printToCache(std::string spiral_out, std::string name, std::vector<i
     }
     #if (defined FFTX_CUDA || FFTX_HIP)
     spiral_out = spiral_out.substr(spiral_out.find("spiral> JIT BEGIN"));
-    #else
-    spiral_out = spiral_out.substr(spiral_out.find("#include"));
     #endif
     cached_file << spiral_out;
     cached_file.close();

--- a/src/include/interface.hpp
+++ b/src/include/interface.hpp
@@ -165,21 +165,24 @@ inline std::string getFromCache(std::string name, std::vector<int> sizes) {
     return oss.str();
 }
 
-inline void printToCache(std::string tmp, std::string name, std::vector<int> sizes) {
-    std::cout << "PrintTo(\"" << tmp << "cache_" << name << "_" << sizes.at(0);
+inline void printToCache(std::string spiral_out, std::string name, std::vector<int> sizes) {
+    std::ofstream cached_file;
+    std::string file_name;
+    file_name.append(getFFTX()+"cache_"+name+"_"+std::to_string(sizes.at(0)));
     for(int i = 1; i< sizes.size(); i++) {
-        std::cout << "x" << sizes.at(i);
+        file_name.append("x"+std::to_string(sizes.at(i)));
     }
     #if defined FFTX_HIP
-        std::cout  << "_HIP" << ".txt\", PrintHIPJIT(c,opts));" << std::endl; 
-        std::cout << "PrintHIPJIT(c,opts);" << std::endl;
+        file_name.append("_HIP.txt");
     #elif defined FFTX_CUDA 
-        std::cout << "_CUDA" << ".txt\", PrintJIT2(c,opts));" << std::endl;   
-        std::cout << "PrintJIT2(c,opts);" << std::endl;
+        file_name.append("_CUDA.txt");
     #else
-        std::cout <<  "_CPU" << ".txt\", opts.prettyPrint(c));" << std::endl; 
-        std::cout << "opts.prettyPrint(c);" << std::endl;
+        file_name.append("_CPU.txt");
     #endif
+    cached_file.open(file_name);
+    cached_file << spiral_out;
+    cached_file.close();
+
 }
 
 inline void getImportAndConf() {
@@ -362,6 +365,7 @@ inline void FFTXProblem::transform(){
                 e.execute(res);
                 executors.insert(std::make_pair(sizes, e));
                 run(e);
+                printToCache(res, name, sizes);
             }
         }
     }

--- a/src/include/interface.hpp
+++ b/src/include/interface.hpp
@@ -183,7 +183,11 @@ inline void printToCache(std::string spiral_out, std::string name, std::vector<i
     while(spiral_out.back() != '}') {
         spiral_out.pop_back();
     }
+    #if (defined FFTX_CUDA || FFTX_HIP)
     spiral_out = spiral_out.substr(spiral_out.find("spiral> JIT BEGIN"));
+    #else
+    spiral_out = spiral_out.substr(spiral_out.find("#include"));
+    #endif
     cached_file << spiral_out;
     cached_file.close();
 


### PR DESCRIPTION
-moved caching to be after RTC calls spiral and runs the transform successfully
-modified how CPU code is cached (removed unnecessary SPIRAL system prints)
-modified how CPU DLL is created by first checking and removing temp directory for previous transform (caused issues for next transform ex. Forward transform temp directory interfereing with inverse transform temp directory)
- added proper checks for system calls