### PR TITLE
Modifications to avoid warning messages on build

### DIFF
--- a/examples/3DDFT_mpi/test3DDFT_mpi_1D.cpp
+++ b/examples/3DDFT_mpi/test3DDFT_mpi_1D.cpp
@@ -426,9 +426,9 @@ int main(int argc, char* argv[]) {
                       href_in_modified[
                         ((k_o * N*2*Mi + j_o * Mi + i)*batch + b)*CI + c
                       ] = (
-                        (0 <= j_i && j_i < N) &&
+                        (j_i < N) &&
                         // (0 <= i && i < Mi) &&
-                        (0 <= k_i && k_i < K)
+                        (k_i < K)
                       ) ? href_in[
                         ((k1 * Ki0*N*Mi + k0 * N*Mi + j_i * Mi + i) * batch + b) * CI + c
                       ] : 0.0;

--- a/src/include/cpubackend.hpp
+++ b/src/include/cpubackend.hpp
@@ -147,13 +147,14 @@ void Executor::execute(std::string result) {
     std::string compile;
     
     char buff[FILENAME_MAX]; //create string buffer to hold path
-    getcwd( buff, FILENAME_MAX );
+    char* getcwdret = getcwd( buff, FILENAME_MAX );
     std::string current_working_dir(buff);
 
     struct stat sb;
 
+    int systemret;
     if(stat((current_working_dir+"/temp").c_str(), &sb) == 0)
-        system("rm -rf temp");
+        systemret = system("rm -rf temp");
         
     if ( DEBUGOUT) {
         std::cout << "created compile\n";
@@ -183,24 +184,24 @@ void Executor::execute(std::string result) {
         exit(-1);
     }
     #if defined(_WIN32) || defined (_WIN64)
-        system("cmake . && make");
+        systemret = system("cmake . && make");
     #elif defined(__APPLE__)
         struct utsname unameData;
         uname(&unameData);
         std::string machine_name(unameData.machine);
         if(machine_name == "arm64")
-            system("cmake -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 . && make");
+            systemret = system("cmake -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 . && make");
         else
-            system("cmake . && make");
+            systemret = system("cmake . && make");
     #else
-        system("cmake . && make"); 
+        systemret = system("cmake . && make"); 
     #endif
     check = chdir(current_working_dir.c_str());
     if(check != 0) {
         std::cout << "failed to change to working directory for runtime code\n";
         exit(-1);
     }
-    // system("cd ..;");
+    // systemret = system("cd ..;");
     if ( DEBUGOUT )
         std::cout << "finished compiling\n";
 }

--- a/src/library/lib_fftx_mpi/fftx_1d_mpi_spiral.cpp
+++ b/src/library/lib_fftx_mpi/fftx_1d_mpi_spiral.cpp
@@ -61,9 +61,9 @@ fftx_plan fftx_plan_distributed_1d_spiral(
   */
 
   // DFT sizes.
-  int inM = M * e;
-  int inN = N * e;
-  int inK = K * e;
+  //  int inM = M * e;
+  //  int inN = N * e;
+  //  int inK = K * e;
 
   int M0 = plan->is_complex ? ceil_div(M*e, p) : ceil_div(M*e/2+1, p);
   int M1 = p;

--- a/src/library/transformer.fftx.precompile.hpp
+++ b/src/library/transformer.fftx.precompile.hpp
@@ -159,9 +159,9 @@ namespace fftx {
     
     virtual std::string name()
     {
-      int bufferLen = 50;
-      char buffer[bufferLen];
-      snprintf(buffer, bufferLen, "%s<%d>[%d,%d,%d]", shortname().c_str(), DIM,
+#define BUFFERLEN 50
+      char buffer[BUFFERLEN];
+      snprintf(buffer, BUFFERLEN, "%s<%d>[%d,%d,%d]", shortname().c_str(), DIM,
                this->m_size[0], this->m_size[1], this->m_size[2]);
       std::string str(buffer);
       return str;

--- a/src/library/transformer.fftx.precompile.hpp
+++ b/src/library/transformer.fftx.precompile.hpp
@@ -159,9 +159,10 @@ namespace fftx {
     
     virtual std::string name()
     {
-      char buffer[50];
-      sprintf(buffer, "%s<%d>[%d,%d,%d]", shortname().c_str(), DIM,
-              this->m_size[0], this->m_size[1], this->m_size[2]);
+      int bufferLen = 50;
+      char buffer[bufferLen];
+      snprintf(buffer, bufferLen, "%s<%d>[%d,%d,%d]", shortname().c_str(), DIM,
+               this->m_size[0], this->m_size[1], this->m_size[2]);
       std::string str(buffer);
       return str;
     }


### PR DESCRIPTION
These checkins are all to avoid warning messages that occur when building on either Linux CPU, Macintosh CPU, or perlmutter CUDA.  I would check frontier, too, but it is down today.