### PR TITLE
For CPU, run pyexe gen_dftbat.py in foreground instead of background,

### DIFF
--- a/src/library/build-lib-code.sh
+++ b/src/library/build-lib-code.sh
@@ -86,33 +86,37 @@ if [ $build_type = "CPU" ]; then
     ##  Generate code for CPU
     echo "Generate CPU code ..."
     waitspiral=false
+    waitafterbatch=true
 
     if [ "$DFTBAT_LIB" = true ]; then
 	##  Build DFT batch for CPU
 	waitspiral=true
-	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type true
-	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type false
+	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type true &
+	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type false &
     fi
     if [ "$PRDFTBAT_LIB" = true ]; then
 	##  Build PRDFT batch for CPU
 	waitspiral=true
-	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type true
-	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type false
+	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type true &
+	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type false &
+    fi
+    if [ "$waitafterbatch" = true ]; then
+	wait		##  wait for the child processes to complete
     fi
     ##  Build the remaining libraries for the specified target
     if [ "$MDDFT_LIB" = true ]; then
 	waitspiral=true
-	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type true
-	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type false
+	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type true &
+	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type false &
     fi
     if [ "$MDPRDFT_LIB" = true ]; then
 	waitspiral=true
-	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type true
-	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type false
+	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type true &
+	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type false &
     fi
     if [ "$RCONV_LIB" = true ]; then
 	waitspiral=true
-	$pyexe gen_files.py fftx_rconv $CPU_SIZES_FILE $build_type true
+	$pyexe gen_files.py fftx_rconv $CPU_SIZES_FILE $build_type true &
     fi
     if [ "$waitspiral" = true ]; then
 	wait		##  wait for the child processes to complete

--- a/src/library/build-lib-code.sh
+++ b/src/library/build-lib-code.sh
@@ -90,29 +90,29 @@ if [ $build_type = "CPU" ]; then
     if [ "$DFTBAT_LIB" = true ]; then
 	##  Build DFT batch for CPU
 	waitspiral=true
-	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type true &
-	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type false &
+	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type true
+	$pyexe gen_dftbat.py fftx_dftbat $DFTBAT_SIZES_FILE $build_type false
     fi
     if [ "$PRDFTBAT_LIB" = true ]; then
 	##  Build PRDFT batch for CPU
 	waitspiral=true
-	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type true &
-	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type false &
+	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type true
+	$pyexe gen_dftbat.py fftx_prdftbat $DFTBAT_SIZES_FILE $build_type false
     fi
     ##  Build the remaining libraries for the specified target
     if [ "$MDDFT_LIB" = true ]; then
 	waitspiral=true
-	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type true &
-	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type false &
+	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type true
+	$pyexe gen_files.py fftx_mddft $CPU_SIZES_FILE $build_type false
     fi
     if [ "$MDPRDFT_LIB" = true ]; then
 	waitspiral=true
-	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type true &
-	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type false &
+	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type true
+	$pyexe gen_files.py fftx_mdprdft $CPU_SIZES_FILE $build_type false
     fi
     if [ "$RCONV_LIB" = true ]; then
 	waitspiral=true
-	$pyexe gen_files.py fftx_rconv $CPU_SIZES_FILE $build_type true &
+	$pyexe gen_files.py fftx_rconv $CPU_SIZES_FILE $build_type true
     fi
     if [ "$waitspiral" = true ]; then
 	wait		##  wait for the child processes to complete


### PR DESCRIPTION
My Linux desktop was freezing up when there were 9 SPIRAL sessions going.

My MacBook Air did not have this problem.  On this MacBook, I found that with the pyexe sessions running in parallel, config took 9 minutes, but with pyexe sessions running in serial, it took 15 minutes. So it does take longer, but not tremendously longer.