### PR TITLE
Updates for code generation for RCONV & PRDFT

### DIFF
--- a/src/include/interface.hpp
+++ b/src/include/interface.hpp
@@ -136,6 +136,12 @@ inline transformTuple_t * getLibTransform(std::string name, std::vector<int> siz
     else if(name == "idftbat" || name == "ib1dft") {
         return fftx_idftbat_Tuple(fftx::point_t<4>({{sizes.at(0), sizes.at(1), sizes.at(2), sizes.at(3)}}));
     }
+    else if(name == "prdftbat" || name == "b1prdft") {
+        return fftx_dftbat_Tuple(fftx::point_t<4>({{sizes.at(0), sizes.at(1), sizes.at(2), sizes.at(3)}}));
+    }
+    else if(name == "iprdftbat" || name == "ib1prdft") {
+        return fftx_idftbat_Tuple(fftx::point_t<4>({{sizes.at(0), sizes.at(1), sizes.at(2), sizes.at(3)}}));
+    }
     else {
         if(DEBUGOUT)
             std::cout << "non-supported fixed library transform" << std::endl; 

--- a/src/library/fftx_prdftbat-frame.g
+++ b/src/library/fftx_prdftbat-frame.g
@@ -54,43 +54,42 @@ if 1 = 1 then
     _wr := APar; if wrstride = "AVec" then _wr := AVec; fi;
     _rd := APar; if rdstride = "AVec" then _rd := AVec; fi;
 
-    ##  we have 6 cases (ignoring AVec/AVec combos for now) all possibly different:
-    ##  Forward and Inverse; APar/APar, AVec/APar, and APar/AVec
+    ##  we have 8 cases (fwd/inverse and APar/AVec combos) all possibly different:
     if fwd then
         if rdstride = "APar" and wrstride = "APar" then
-            t := let ( TFCall ( TTensorI ( PRDFT ( fftlen, sign ), nbatch, _wr, _rd ),
+            t := let ( TFCall ( TTensorI ( PRDFT ( fftlen, sign ), nbatch, APar, _rd ),
                                 rec ( fname := name, params := [] ) ) );
         elif rdstride = "APar" and wrstride = "AVec" then
             t := let ( TFCall ( Prm ( fTensor ( L ( PRDFT1 ( fftlen, sign ).dims()[1]/2 * nbatch,
                                                     PRDFT1 ( fftlen, sign ).dims()[1]/2 ),
                                                 fId (2) ) ) *
                                 TTensorI ( PRDFT1 ( fftlen, sign ), nbatch, APar, _rd ),
-                               rec ( fname := name, params := [] ) ) );
-        elif rdstride = "AVec" and wrstride = "APar" then
-            t := let ( TFCall ( TTensorI ( PRDFT1 ( fftlen, sign ), nbatch, APar, _rd ) *
-                                Prm ( fTensor ( L ( PRDFT1 ( fftlen, sign ).dims()[2]/2 * nbatch, nbatch ), fId (2) ) ),
                                 rec ( fname := name, params := [] ) ) );
-        else
-            ##  AVec/AVec - not implemented
-            PrintLine ( "Avec/Avec case not implemented" );
+        elif rdstride = "AVec" and wrstride = "APar" then
+            t := let ( TFCall ( TTensorI ( PRDFT ( fftlen, sign ), nbatch, APar, _rd ),
+                                rec ( fname := name, params := [] ) ) );
+        else            ##  rdstride = "AVec" and wrstride = "AVec"
+            t := let ( TFCall ( Prm ( fTensor ( L ( PRDFT1 ( fftlen, sign).dims()[1]/2 * nbatch,
+                                                    PRDFT1 ( fftlen, sign).dims()[1]/2),
+                                                fId (2) ) ) *
+                                TTensorI ( PRDFT1 ( fftlen, sign ), nbatch, APar, _rd ),
+                                rec ( fname := name, params := [] ) ) );
         fi;
     else
         if rdstride = "APar" and wrstride = "APar" then
-            t := let ( TFCall ( TRC ( TTensorI ( PRDFT ( fftlen, sign), nbatch, _wr, _rd ) ),
+            t := let ( TFCall ( TTensorI ( IPRDFT ( fftlen, sign ), nbatch, _wr, _rd ),
                                 rec ( fname := name, params := [] ) ) );
         elif rdstride = "APar" and wrstride = "AVec" then
-            t := let ( TFCall ( Prm ( fTensor ( L ( IPRDFT1 ( fftlen, sign ).dims()[1]/2 * nbatch,
-                                                    IPRDFT1 ( fftlen, sign ).dims()[1]/2 ),
-                                                fId (2) ) ) *
-                                TTensorI ( IPRDFT1 ( fftlen, sign ), nbatch, APar, _rd ),
-                                rec ( fname := name, params := [] ) ) );        
+            t := let ( TFCall ( TTensorI ( IPRDFT ( fftlen, sign ), nbatch, _wr, _rd ),
+                                rec ( fname := name, params := [] ) ) );
         elif rdstride = "AVec" and wrstride = "APar" then
-            t := let ( TFCall ( TTensorI ( IPRDFT ( fftlen, sign ), nbatch, APar, APar ) *
+            t := let ( TFCall ( TTensorI ( IPRDFT ( fftlen, sign ), nbatch, _wr, APar ) *
                                 Prm ( fTensor ( L ( IPRDFT1 ( fftlen, sign ).dims()[2]/2 * nbatch, nbatch ), fId (2) ) ),
                                 rec ( fname := name, params := [] ) ) );
-        else
-            ##  AVec/AVec - not implemented
-            PrintLine ( "Avec/Avec case not implemented" );
+        else            ##  rdstride = "AVec" and wrstride = "AVec"
+            t := let ( TFCall ( TTensorI ( IPRDFT ( fftlen, sign ), nbatch, _wr, APar ) *
+                                Prm ( fTensor ( L ( IPRDFT1 ( fftlen, sign ).dims()[2]/2 * nbatch, nbatch ), fId (2) ) ),
+                                rec ( fname := name, params := [] ) ) );
         fi;
     fi;
 

--- a/src/library/fftx_rconv-frame.g
+++ b/src/library/fftx_rconv-frame.g
@@ -37,30 +37,6 @@ if 1 = 1 then
     
     PrintLine("fftx_rconv-frame: name = ", name, ", cube = ", szcube, ", jitname = ", jitname, ";\t\t##PICKME##");
 
-    ## This assumes FFTX_COMPLEX_TRUNC_LAST==0
-    ##szhalfcube := [Int(szcube[1]/2)+1]::Drop(szcube,1);
-    ##  szhalfcube := [szcube[1]/2+1]::Drop(szcube,1);
-    ## This assumes FFTX_COMPLEX_TRUNC_LAST==1
-    ##  szhalfcube := DropLast(szcube,1)::[Int(Last(szcube)/2)+1];
-    ##  szhalfcube := DropLast(szcube,1)::[Last(szcube)/2+1];
-    # var_1:= var("var_1", BoxND(szhalfcube, TReal));
-    # var_2:= var("var_2", BoxND(szhalfcube, TReal));
-    # var_3:= var("var_3", BoxND(szcube, TReal));
-    # var_4:= var("var_4", BoxND(szcube, TReal));
-    # var_5:= var("var_5", BoxND(szhalfcube, TReal));
-    # var_3:= X;
-    # var_4:= Y;
-    # symvar := var("sym", TPtr(TReal));
-    # t := TFCall(TDecl(TDAG([
-    #     TDAGNode(MDPRDFT(szcube,-1), var_1,var_3),
-    #     TDAGNode(Diag(diagTensor(FDataOfs(symvar,Product(szhalfcube),0),fConst(TReal, 2, 1))), var_2,var_1),
-    #     TDAGNode(IMDPRDFT(szcube,1), var_4,var_2),
-    #               ]),
-    #         [var_1,var_2]
-    #         ),
-    #     rec(fname:=name, params:= [symvar])
-    # );
-
     symvar := var ( "sym", TPtr(TReal) );
     t := TFCall ( IMDPRDFT ( szcube, 1 ) * RCDiag ( FDataOfs ( symvar, MDPRDFT ( szcube, -1 ).dims()[1], 0 ) ) *
                   MDPRDFT ( szcube, -1 ), 

--- a/src/library/fftx_rconv-frame.g
+++ b/src/library/fftx_rconv-frame.g
@@ -41,26 +41,32 @@ if 1 = 1 then
     ##szhalfcube := [Int(szcube[1]/2)+1]::Drop(szcube,1);
     ##  szhalfcube := [szcube[1]/2+1]::Drop(szcube,1);
     ## This assumes FFTX_COMPLEX_TRUNC_LAST==1
-    szhalfcube := DropLast(szcube,1)::[Int(Last(szcube)/2)+1];
+    ##  szhalfcube := DropLast(szcube,1)::[Int(Last(szcube)/2)+1];
     ##  szhalfcube := DropLast(szcube,1)::[Last(szcube)/2+1];
-    var_1:= var("var_1", BoxND(szhalfcube, TReal));
-    var_2:= var("var_2", BoxND(szhalfcube, TReal));
-    var_3:= var("var_3", BoxND(szcube, TReal));
-    var_4:= var("var_4", BoxND(szcube, TReal));
-    var_5:= var("var_5", BoxND(szhalfcube, TReal));
-    var_3:= X;
-    var_4:= Y;
-    symvar := var("sym", TPtr(TReal));
-    t := TFCall(TDecl(TDAG([
-        TDAGNode(MDPRDFT(szcube,-1), var_1,var_3),
-        TDAGNode(Diag(diagTensor(FDataOfs(symvar,Product(szhalfcube),0),fConst(TReal, 2, 1))), var_2,var_1),
-        TDAGNode(IMDPRDFT(szcube,1), var_4,var_2),
-                  ]),
-            [var_1,var_2]
-            ),
-        rec(fname:=name, params:= [symvar])
-    );
-    
+    # var_1:= var("var_1", BoxND(szhalfcube, TReal));
+    # var_2:= var("var_2", BoxND(szhalfcube, TReal));
+    # var_3:= var("var_3", BoxND(szcube, TReal));
+    # var_4:= var("var_4", BoxND(szcube, TReal));
+    # var_5:= var("var_5", BoxND(szhalfcube, TReal));
+    # var_3:= X;
+    # var_4:= Y;
+    # symvar := var("sym", TPtr(TReal));
+    # t := TFCall(TDecl(TDAG([
+    #     TDAGNode(MDPRDFT(szcube,-1), var_1,var_3),
+    #     TDAGNode(Diag(diagTensor(FDataOfs(symvar,Product(szhalfcube),0),fConst(TReal, 2, 1))), var_2,var_1),
+    #     TDAGNode(IMDPRDFT(szcube,1), var_4,var_2),
+    #               ]),
+    #         [var_1,var_2]
+    #         ),
+    #     rec(fname:=name, params:= [symvar])
+    # );
+
+    symvar := var ( "sym", TPtr(TReal) );
+    t := TFCall ( IMDPRDFT ( szcube, 1 ) * RCDiag ( FDataOfs ( symvar, MDPRDFT ( szcube, -1 ).dims()[1], 0 ) ) *
+                  MDPRDFT ( szcube, -1 ), 
+                  rec ( fname := name, params := [symvar] )
+);
+
     opts := conf.getOpts(t);
     if not IsBound ( libdir ) then
         libdir := "srcs";


### PR DESCRIPTION
Revise RCONV to permit odd dimension sizes (per Franz's s-p-fftx example)
Revise PRDFT code gen to handle all 8 cases (fwd/inv and apar/avec variants)
Cleanup validation script for PRDFT
Add additional names to interface.hpp
 