### PR TITLE
Wrap library functions, new rconv spiral template

### DIFF
--- a/src/library/fftx_rconv-frame.g
+++ b/src/library/fftx_rconv-frame.g
@@ -37,28 +37,19 @@ if 1 = 1 then
     
     PrintLine("fftx_rconv-frame: name = ", name, ", cube = ", szcube, ", jitname = ", jitname, ";\t\t##PICKME##");
 
-    ## This assumes FFTX_COMPLEX_TRUNC_LAST==0
-    ##szhalfcube := [Int(szcube[1]/2)+1]::Drop(szcube,1);
-    ##  szhalfcube := [szcube[1]/2+1]::Drop(szcube,1);
-    ## This assumes FFTX_COMPLEX_TRUNC_LAST==1
-    szhalfcube := DropLast(szcube,1)::[Int(Last(szcube)/2)+1];
-    ##  szhalfcube := DropLast(szcube,1)::[Last(szcube)/2+1];
-    var_1:= var("var_1", BoxND(szhalfcube, TReal));
-    var_2:= var("var_2", BoxND(szhalfcube, TReal));
-    var_3:= var("var_3", BoxND(szcube, TReal));
-    var_4:= var("var_4", BoxND(szcube, TReal));
-    var_5:= var("var_5", BoxND(szhalfcube, TReal));
-    var_3:= X;
-    var_4:= Y;
-    symvar := var("sym", TPtr(TReal));
-    t := TFCall(TDecl(TDAG([
-        TDAGNode(MDPRDFT(szcube,-1), var_1,var_3),
-        TDAGNode(Diag(diagTensor(FDataOfs(symvar,Product(szhalfcube),0),fConst(TReal, 2, 1))), var_2,var_1),
-        TDAGNode(IMDPRDFT(szcube,1), var_4,var_2),
-                  ]),
-            [var_1,var_2]
-            ),
-        rec(fname:=name, params:= [symvar])
+    dx := szcube[1];
+    dy := szcube[2];
+    dz := szcube[3];
+    dzadj := Int(dz / 2) + 1;
+    t := let ( symvar := var ( "sym", TPtr(TReal) ),
+               TFCall (
+                   Compose ( [
+                       IMDPRDFT ( [dx, dy, dz], 1),
+                       RCDiag ( FDataOfs ( symvar, dx * dy * dzadj * 2, 0 ) ),
+                       MDPRDFT ( [dx, dy, dz], -1 )
+                   ]),
+                   rec ( fname := name, params := [symvar] )
+               )
     );
     
     opts := conf.getOpts(t);

--- a/src/library/gen_files.py
+++ b/src/library/gen_files.py
@@ -132,6 +132,7 @@ def body_public_header ( script ):
     str.append ( '//  array of sizes, each element is a struct of type fftx::point_t<3> specifying the X,\n' )
     str.append ( '//  Y, and Z dimensions\n\n' )
 
+    str.append ( 'extern "C" {\n\n' )
     str.append ( f'fftx::point_t<3> * {script.file_stem}{script.decor_platform}QuerySizes ();' + '\n' )
     str.append ( f'#define {script.file_stem}QuerySizes {script.file_stem}{script.decor_platform}QuerySizes' + '\n\n' )
 
@@ -165,15 +166,15 @@ def body_public_header ( script ):
 
     if script.xform_name != 'psatd':
         str.append ( '//  Wrapper functions to allow python to call CUDA/HIP GPU code.\n\n' )
-        str.append ( 'extern "C" {\n\n' )
+        ##  str.append ( 'extern "C" {\n\n' )
         str.append ( f'int  {script.file_stem}{script.decor_platform}python_init_wrapper ( int * req );' + '\n' )
 
         str.append ( f'void {script.file_stem}{script.decor_platform}python_run_wrapper ' )
         str.append ( '( int * req, double * output, double * input, double * sym );\n' )
 
-        str.append ( f'void {script.file_stem}{script.decor_platform}python_destroy_wrapper ( int * req );' + '\n\n}\n\n' )
+        str.append ( f'void {script.file_stem}{script.decor_platform}python_destroy_wrapper ( int * req );' + '\n\n' )
 
-    str.append ( '#endif\n\n' )
+    str.append ( '}\n\n#endif\n\n' )
 
     return str.get();
 
@@ -208,6 +209,7 @@ def library_api ( script ):
     str.append ( '//  Y, and Z dimensions of a transform in the library.  <N> is the number of sizes defined;\n' )
     str.append ( '//  the last entry in the returned list has all dimensions equal 0.\n\n' )
 
+    str.append ( 'extern "C" {\n\n' )
     str.append ( f'fftx::point_t<3> * {script.file_stem}{script.decor_platform}QuerySizes ()' + '\n{\n' )
     str.append ( '    fftx::point_t<3> *wp = (fftx::point_t<3> *) ' )
     str.append ( f' malloc ( sizeof ( AllSizes3_{script.args.platform} ) );' + '\n' )
@@ -276,6 +278,8 @@ def library_api ( script ):
 
     str.append ( '    return;\n' )
     str.append ( '}\n\n' )
+
+    str.append ( '}\n\n' )              ## Close the opening 'extern "C"'
 
     return str.get();
 


### PR DESCRIPTION
Wrap generated library functions with 'extern "C" {    }'
Change the Spiral script template for rconv (to match SpiralPy and validates vs NumPy)
