### PR TITLE
Add CUDALINK_DIR for building lib_fftx_mpi (when CUDA)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,10 +35,10 @@ else ()
 endif ()
 
 ##  Check if a Fortran compiler is available
-if ( Fortran_ENABLED )
+if ( Fortran_ENABLED AND ${MPI_FOUND} )
     message ( STATUS "Fortran compiler found: ${CMAKE_Fortran_COMPILER}; will build Fortran example" )
     ##  Build the Fortran example
     manage_add_subdir ( fortran       TRUE      TRUE )
 else ()
-    message ( STATUS "No Fortran compiler found.  Skipping Fortran example build." )
+    message ( STATUS "A Fortran compiler and MPI are required,  Skipping Fortran example build." )
 endif ()

--- a/src/library/lib_fftx_mpi/CMakeLists.txt
+++ b/src/library/lib_fftx_mpi/CMakeLists.txt
@@ -44,6 +44,7 @@ add_mpi_decorations_to_target ( ${_lib_name} )
 
 if ( ${_codegen} STREQUAL "CUDA" )
     set_property    ( TARGET ${_lib_name} PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS ON )
+    target_link_directories ( ${_lib_name} PRIVATE ${CUDALINK_DIR} )
     target_link_libraries ( ${_lib_name} PRIVATE ${LIBS_FOR_CUDA} )
 endif ()
 


### PR DESCRIPTION
* Add CUDALINK_DIR for building lib_fftx_mpi (when CUDA)
* Only build Fortran example when both a Fortran compiler and MPI are found
